### PR TITLE
Centralize version management

### DIFF
--- a/algorithm/pom.xml
+++ b/algorithm/pom.xml
@@ -39,7 +39,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/asio/pom.xml
+++ b/asio/pom.xml
@@ -39,13 +39,11 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>system</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/bind/pom.xml
+++ b/bind/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/circular/pom.xml
+++ b/circular/pom.xml
@@ -32,56 +32,47 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>preprocessor</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>config</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>utility</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>iterator</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>container</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
 
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>type-traits</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>move</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>detail</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/concept/pom.xml
+++ b/concept/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/date-time/pom.xml
+++ b/date-time/pom.xml
@@ -42,79 +42,66 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>config</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>detail</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>exception</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>mpl</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>type-traits</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>smart-ptr</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>range</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>iterator</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>concept</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>lexical-cast</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>functional</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>math</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/detail/pom.xml
+++ b/detail/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/exception/pom.xml
+++ b/exception/pom.xml
@@ -35,7 +35,6 @@
             <groupId>org.boost</groupId>
             <artifactId>config</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/filesystem/pom.xml
+++ b/filesystem/pom.xml
@@ -35,55 +35,46 @@
             <groupId>org.boost</groupId>
             <artifactId>config</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>system</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>detail</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>type-traits</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>iterator</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>smart-ptr</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>io</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>functional</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>range</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/function/pom.xml
+++ b/function/pom.xml
@@ -32,13 +32,11 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>bind</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/function_types/pom.xml
+++ b/function_types/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/functional/pom.xml
+++ b/functional/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/fusion/pom.xml
+++ b/fusion/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/integer/pom.xml
+++ b/integer/pom.xml
@@ -34,13 +34,11 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>math</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/interprocess/pom.xml
+++ b/interprocess/pom.xml
@@ -32,31 +32,26 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>detail</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>move</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>config</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>date-time</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/intrusive/pom.xml
+++ b/intrusive/pom.xml
@@ -35,19 +35,16 @@
             <groupId>org.boost</groupId>
             <artifactId>move</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>preprocessor</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 </project>

--- a/iostreams/pom.xml
+++ b/iostreams/pom.xml
@@ -40,61 +40,51 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>config</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>detail</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>exception</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>type-traits</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>utility</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>range</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>iterator</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>concept</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>smart-ptr</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 </project>

--- a/iterator/pom.xml
+++ b/iterator/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -39,7 +39,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/lexical-cast/pom.xml
+++ b/lexical-cast/pom.xml
@@ -32,19 +32,16 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>numeric</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>container</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
     

--- a/math/pom.xml
+++ b/math/pom.xml
@@ -28,7 +28,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/move/pom.xml
+++ b/move/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/mpl/pom.xml
+++ b/mpl/pom.xml
@@ -32,13 +32,11 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>preprocessor</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/numeric/pom.xml
+++ b/numeric/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/optional/pom.xml
+++ b/optional/pom.xml
@@ -32,49 +32,41 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>move</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>mpl</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>type-traits</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>config</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>detail</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>exception</artifactId>
             <type>nar</type>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>exception</artifactId>
             <type>nar</type>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/phoenix/pom.xml
+++ b/phoenix/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -151,5 +151,310 @@
             </build>
         </profile>
     </profiles>
-</project>
+
+    <dependencyManagement>
+    <dependencies>
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>asio</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>algorithm</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>bind</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>concept</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>config</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>container</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>core</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>date-time</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>detail</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>exception</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>filesystem</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>function</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>function_types</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>functional</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>fusion</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>integer</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>io</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>iostreams</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>iterator</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>interprocess</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>lambda</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>lexical-cast</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>math</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>move</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>mpl</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>numeric</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>optional</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>phoenix</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>predef</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>preprocessor</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>proto</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>range</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>regex</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>smart-ptr</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>spirit</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>system</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>type-traits</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>type_index</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>typeof</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>utility</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>variant</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>circular</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+
+    <dependency>
+    <groupId>org.boost</groupId>
+    <artifactId>intrusive</artifactId>
+    <version>${project.version}</version>
+    <type>nar</type>
+    </dependency>
+    </dependencies>
+    </dependencyManagement>
+    </project>
 

--- a/preprocessor/pom.xml
+++ b/preprocessor/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -32,25 +32,21 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>fusion</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>typeof</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>range</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/range/pom.xml
+++ b/range/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/regex/pom.xml
+++ b/regex/pom.xml
@@ -35,49 +35,41 @@
             <groupId>org.boost</groupId>
             <artifactId>config</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>detail</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>exception</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>smart-ptr</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>mpl</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>type-traits</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>functional</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>integer</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 </project>

--- a/smart-ptr/pom.xml
+++ b/smart-ptr/pom.xml
@@ -35,19 +35,16 @@
             <groupId>org.boost</groupId>
             <artifactId>exception</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>utility</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>predef</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 </project>

--- a/spirit/pom.xml
+++ b/spirit/pom.xml
@@ -32,133 +32,111 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>mpl</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>config</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>detail</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>type-traits</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>optional</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>exception</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>utility</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>move</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>smart-ptr</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>iterator</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>concept</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>phoenix</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>proto</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>variant</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>math</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>regex</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>function</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>function_types</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>iostreams</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>lexical-cast</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>io</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/system/pom.xml
+++ b/system/pom.xml
@@ -35,25 +35,21 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>config</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>predef</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>utility</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/type-traits/pom.xml
+++ b/type-traits/pom.xml
@@ -32,31 +32,26 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>mpl</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>utility</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>detail</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>preprocessor</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/type_index/pom.xml
+++ b/type_index/pom.xml
@@ -32,13 +32,11 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>functional</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/typeof/pom.xml
+++ b/typeof/pom.xml
@@ -32,7 +32,6 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 

--- a/variant/pom.xml
+++ b/variant/pom.xml
@@ -32,13 +32,11 @@
             <groupId>org.boost</groupId>
             <artifactId>core</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
         <dependency>
             <groupId>org.boost</groupId>
             <artifactId>type_index</artifactId>
             <type>nar</type>
-            <version>1.57.0+nar.10</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This should make it easier to manage the version of all the various submodules,
as well as make it easier for users, who can do the following to get this same
<dependencyManagement> block:

<dependency>
  <group>org.boost</group>
  <artifact>parent</artifact>
  <version>1.57.0+nar.10</version>
  <scope>import</scope>
</dependency>

This is for issue #19
